### PR TITLE
CTM-4435: Исключил проверку model.asset.mediaType для только что сдел…

### DIFF
--- a/TZImagePickerController/TZImagePickerController/TZImagePickerController.m
+++ b/TZImagePickerController/TZImagePickerController/TZImagePickerController.m
@@ -1059,6 +1059,9 @@
 + (BOOL)isAssetNotSelectable:(TZAssetModel *)model tzImagePickerVc:(TZImagePickerController *)tzImagePickerVc {
     BOOL notSelectable = tzImagePickerVc.selectedModels.count >= tzImagePickerVc.maxImagesCount;
     if (tzImagePickerVc.selectedModels && tzImagePickerVc.selectedModels.count > 0 && !tzImagePickerVc.allowPickingMultipleVideo) {
+        if (model.type == TZAssetModelMediaTypePhoto) { // `TZAssetModelMediaTypePhoto` mutually exclusive to `PHAssetMediaTypeVideo`
+            return notSelectable;
+        }
         if (model.asset.mediaType == PHAssetMediaTypeVideo) {
             notSelectable = true;
         }


### PR DESCRIPTION
…анных без сохранения UIImage (у которых нет .mediaType).